### PR TITLE
Display role on alumni page, Nick name logic

### DIFF
--- a/notebooks/create_htmls.ipynb
+++ b/notebooks/create_htmls.ipynb
@@ -17,7 +17,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 2,
+            "execution_count": 89,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -34,7 +34,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 3,
+            "execution_count": 90,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -63,7 +63,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 4,
+            "execution_count": 91,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -98,7 +98,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 5,
+            "execution_count": 92,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -115,7 +115,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 6,
+            "execution_count": 93,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -148,7 +148,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 7,
+            "execution_count": 94,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -190,7 +190,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 8,
+            "execution_count": 95,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -216,7 +216,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 9,
+            "execution_count": 96,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -238,7 +238,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 10,
+            "execution_count": 97,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -252,7 +252,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 11,
+            "execution_count": 98,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -290,7 +290,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 12,
+            "execution_count": 99,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -317,7 +317,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 13,
+            "execution_count": 100,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -331,11 +331,12 @@
                 "info_json_df[\"full_name\"] = info_json_df.apply(\n",
                 "    lambda row: (\n",
                 "        row[\"nick_name\"] + \" \" + row[\"last_name\"]\n",
-                "        if pd.notna(row[\"nick_name\"])\n",
+                "        if \"nick_name\" in row and pd.notna(row[\"nick_name\"])\n",
                 "        else row[\"first_name\"] + \" \" + row[\"last_name\"]\n",
                 "    ),\n",
                 "    axis=1,\n",
                 ")\n",
+                "\n",
                 "info_json_dict = info_json_df.to_dict(\"index\")"
             ]
         },
@@ -348,7 +349,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 14,
+            "execution_count": 101,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -375,7 +376,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 15,
+            "execution_count": 102,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -403,7 +404,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 16,
+            "execution_count": 103,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -416,7 +417,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 17,
+            "execution_count": 104,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -438,7 +439,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 18,
+            "execution_count": 105,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -454,7 +455,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 19,
+            "execution_count": 106,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -470,7 +471,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 20,
+            "execution_count": 107,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -493,7 +494,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 21,
+            "execution_count": 108,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -518,7 +519,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 22,
+            "execution_count": 109,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -541,7 +542,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 23,
+            "execution_count": 110,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -570,7 +571,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 24,
+            "execution_count": 111,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -600,7 +601,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 25,
+            "execution_count": 112,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -614,7 +615,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 26,
+            "execution_count": 113,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -623,7 +624,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 27,
+            "execution_count": 114,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -635,7 +636,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 28,
+            "execution_count": 115,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -657,7 +658,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 29,
+            "execution_count": 116,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -668,7 +669,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 30,
+            "execution_count": 117,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -687,7 +688,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 31,
+            "execution_count": 118,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -709,7 +710,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 32,
+            "execution_count": 119,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -719,9 +720,25 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 33,
+            "execution_count": 120,
             "metadata": {},
-            "outputs": [],
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "/var/folders/4k/bxm54w1d3tn2gj52lyx4vp200000gn/T/ipykernel_21143/2381851519.py:13: FutureWarning: Not prepending group keys to the result index of transform-like apply. In the future, the group keys will be included in the index, regardless of whether the applied function returns a like-indexed object.\n",
+                        "To preserve the previous behavior, use\n",
+                        "\n",
+                        "\t>>> .groupby(..., group_keys=False)\n",
+                        "\n",
+                        "To adopt the future behavior and silence this warning, use \n",
+                        "\n",
+                        "\t>>> .groupby(..., group_keys=True)\n",
+                        "  req_exp_df_most_recent = req_exp_df.groupby(\"id\").apply(most_recent_row_end_date)\n"
+                    ]
+                }
+            ],
             "source": [
                 "alumni_filtered_edu_df = edu_df[edu_df[\"end_date\"].notna()]\n",
                 "req_edu_df = alumni_filtered_edu_df.loc[\n",
@@ -735,14 +752,12 @@
                 "    (alumni_filtered_exp_df[\"institution\"] == INSTITUTION_FILTER)\n",
                 "    | (alumni_filtered_exp_df[\"group\"].isin(GROUP_FILTER))\n",
                 "]\n",
-                "req_exp_df_most_recent = (\n",
-                "    req_exp_df.groupby(\"id\").apply(most_recent_row_end_date).droplevel(0)\n",
-                ")"
+                "req_exp_df_most_recent = req_exp_df.groupby(\"id\").apply(most_recent_row_end_date)\n"
             ]
         },
         {
             "cell_type": "code",
-            "execution_count": 34,
+            "execution_count": 121,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -754,7 +769,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 35,
+            "execution_count": 122,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -767,7 +782,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 36,
+            "execution_count": 123,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -790,7 +805,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 37,
+            "execution_count": 124,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -812,7 +827,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 38,
+            "execution_count": 125,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -827,7 +842,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 39,
+            "execution_count": 126,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -836,7 +851,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 40,
+            "execution_count": 127,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -847,7 +862,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 41,
+            "execution_count": 128,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -861,7 +876,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 42,
+            "execution_count": 129,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -884,7 +899,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 43,
+            "execution_count": 130,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -931,7 +946,7 @@
             "name": "python",
             "nbconvert_exporter": "python",
             "pygments_lexer": "ipython3",
-            "version": "3.10.12"
+            "version": "3.8.2"
         },
         "orig_nbformat": 4
     },

--- a/notebooks/create_htmls.ipynb
+++ b/notebooks/create_htmls.ipynb
@@ -17,7 +17,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 89,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -34,7 +34,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 90,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -63,7 +63,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 91,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -98,7 +98,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 92,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -115,7 +115,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 93,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -148,7 +148,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 94,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -190,7 +190,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 95,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -216,7 +216,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 96,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -238,7 +238,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 97,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -252,7 +252,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 98,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -290,7 +290,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 99,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -317,7 +317,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 100,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -349,7 +349,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 101,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -376,7 +376,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 102,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -404,7 +404,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 103,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -417,7 +417,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 104,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -439,7 +439,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 105,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -455,7 +455,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 106,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -471,7 +471,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 107,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -494,7 +494,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 108,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -519,7 +519,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 109,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -542,7 +542,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 110,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -571,7 +571,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 111,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -601,7 +601,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 112,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -615,7 +615,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 113,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -624,7 +624,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 114,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -636,7 +636,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 115,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -658,7 +658,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 116,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -669,7 +669,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 117,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -688,7 +688,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 118,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -710,7 +710,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 119,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -720,25 +720,9 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 120,
+            "execution_count": null,
             "metadata": {},
-            "outputs": [
-                {
-                    "name": "stderr",
-                    "output_type": "stream",
-                    "text": [
-                        "/var/folders/4k/bxm54w1d3tn2gj52lyx4vp200000gn/T/ipykernel_21143/2381851519.py:13: FutureWarning: Not prepending group keys to the result index of transform-like apply. In the future, the group keys will be included in the index, regardless of whether the applied function returns a like-indexed object.\n",
-                        "To preserve the previous behavior, use\n",
-                        "\n",
-                        "\t>>> .groupby(..., group_keys=False)\n",
-                        "\n",
-                        "To adopt the future behavior and silence this warning, use \n",
-                        "\n",
-                        "\t>>> .groupby(..., group_keys=True)\n",
-                        "  req_exp_df_most_recent = req_exp_df.groupby(\"id\").apply(most_recent_row_end_date)\n"
-                    ]
-                }
-            ],
+            "outputs": [],
             "source": [
                 "alumni_filtered_edu_df = edu_df[edu_df[\"end_date\"].notna()]\n",
                 "req_edu_df = alumni_filtered_edu_df.loc[\n",
@@ -757,7 +741,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 121,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -769,7 +753,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 122,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -782,7 +766,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 123,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -805,7 +789,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 124,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -827,7 +811,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 125,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -842,7 +826,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 126,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -851,7 +835,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 127,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -862,7 +846,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 128,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -876,7 +860,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 129,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -899,7 +883,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 130,
+            "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -921,13 +905,6 @@
                 "        content=article_content_df.to_dict(\"index\"),\n",
                 "    )"
             ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": []
         }
     ],
     "metadata": {

--- a/templates/news.html.j2
+++ b/templates/news.html.j2
@@ -213,7 +213,7 @@
         try {
             data = context.getImageData(0, 0, width, height);
         } catch(e) {
-            /* security error, img on diff domain */alert('x');
+           
             return defaultRGB;
         }
         


### PR DESCRIPTION
Changes made:

- On Alumni page Tripps role was NaN. Now latest is being displayed
- Made changes to the notebook to concat names and handle if nick name is absent
- Removed security check on other domains from news.html.j2 so that html file can be opened on local system
-